### PR TITLE
feat: autoscroll on preview

### DIFF
--- a/tutorindigo/templates/indigo/lms/templates/footer.html
+++ b/tutorindigo/templates/indigo/lms/templates/footer.html
@@ -20,7 +20,7 @@ fx_copyrights_text = fx_static._(fx_footer.get('copyrights_text', '')) or ''
 
 <!-- NEW IN INDIGO update footer -->
 
-<div class="wrapper wrapper-footer p-0">
+<div id="fx-footer" class="wrapper wrapper-footer p-0">
   <footer id="footer" class="tutor-container"
     ## When rendering the footer through the branding API,
     ## the direction may not be set on the parent element,

--- a/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_header_navbar_links.html
+++ b/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_header_navbar_links.html
@@ -5,7 +5,7 @@ header = fx_static.get_fx_config_value('header')
 header_sections = fx_static.get_fx_link_sections(header.get('sections', []))
 %>
 
-<div class="main">
+<div id="fx-header" class="main">
 % for h_section in header_sections:
     <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
         <a class="${'active ' if h_section['link'] == request.path else ''}tab-nav-link" href="${h_section['link']}"

--- a/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_page/_section_faq_section_v1.html
+++ b/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_page/_section_faq_section_v1.html
@@ -3,6 +3,10 @@
 <%namespace name='fx_static' file='../fx_static_content.html'/>
 
 <%
+id_tag = page_contents.get('key')
+if id_tag:
+    id_tag = f'id="{id_tag}"'
+
 fx_title = fx_static._(page_contents.get('title'))
 declared_faq_items = page_contents.get('faq_items', [])
 
@@ -20,7 +24,7 @@ for faq_item in declared_faq_items:
     })
 %>
 
-<div class="platformMainWrap">
+<div ${id_tag} class="platformMainWrap">
     <div class="middleHeading">
         <h2 class="sectionWrapper__sectionHeading text-center">
             ${fx_title | fx_static.br}

--- a/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_page/_section_featured_courses_v1.html
+++ b/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_page/_section_featured_courses_v1.html
@@ -3,6 +3,10 @@
 <%namespace name='fx_static' file='../fx_static_content.html'/>
 
 <%
+id_tag = page_contents.get('key')
+if id_tag:
+    id_tag = f'id="{id_tag}"'
+
 fx_title = fx_static._(page_contents.get('title'))
 fx_description = fx_static._(page_contents.get('description'))
 fx_grid_type = page_contents.get('grid_type', '')
@@ -11,7 +15,7 @@ if fx_grid_type not in ['max-3', 'max-6', 'max-9', 'all', 'categorised']:
 %>
 
 
-<div class="platformMainWrap courseMainWrapper">
+<div ${id_tag} class="platformMainWrap courseMainWrapper">
     <div class="middleHeading">
         <h2 class="sectionWrapper__sectionHeading text-center">
             ${fx_title | fx_static.br}

--- a/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_page/_section_hero_section_v1.html
+++ b/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_page/_section_hero_section_v1.html
@@ -3,6 +3,10 @@
 <%namespace name='fx_static' file='../fx_static_content.html'/>
 
 <%
+id_tag = page_contents.get('key')
+if id_tag:
+    id_tag = f'id="{id_tag}"'
+
 fx_title = fx_static._(page_contents.get('title'))
 fx_description = fx_static._(page_contents.get('description'))
 image_url = page_contents.get('hero_image')
@@ -12,7 +16,7 @@ else:
     style = "background-color: black;"
 %>
 
-<div class="mainBanner" style="${style}">
+<div ${id_tag} class="mainBanner" style="${style}">
 
   <h1 class="mainBanner__heading">
     ${fx_title | fx_static.br}

--- a/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_page/_section_live_metrics_section_v1.html
+++ b/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_page/_section_live_metrics_section_v1.html
@@ -3,6 +3,10 @@
 <%namespace name='fx_static' file='../fx_static_content.html'/>
 
 <%
+id_tag = page_contents.get('key')
+if id_tag:
+    id_tag = f'id="{id_tag}"'
+
 from crum import get_current_request
 from futurex_openedx_extensions.helpers.tenants import get_all_tenants_info
 from futurex_openedx_extensions.dashboard.statistics.live import get_live_statistics
@@ -56,7 +60,7 @@ alignment = page_contents.get('alignment')
 alignment = alignment if alignment in ['start', 'end'] else 'center'
 %>
 
-<div class="platformMainWrap">
+<div ${id_tag} class="platformMainWrap">
     % if fx_title or fx_description:
     <div class="middleHeading">
         % if fx_title:

--- a/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_page/_section_paragraph_section_v1.html
+++ b/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_page/_section_paragraph_section_v1.html
@@ -3,10 +3,14 @@
 <%namespace name='fx_static' file='../fx_static_content.html'/>
 
 <%
+id_tag = page_contents.get('key')
+if id_tag:
+    id_tag = f'id="{id_tag}"'
+
 fx_html_content = fx_static._(page_contents.get('paragraph'))
 %>
 
-<div class="fx-raw-html-paragraph-container">
+<div ${id_tag} class="fx-raw-html-paragraph-container">
 
     ${fx_html_content | n}
 

--- a/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_page/_section_side_image_v1.html
+++ b/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_page/_section_side_image_v1.html
@@ -6,6 +6,10 @@ from django.utils.translation import gettext as _
 <%namespace name='fx_static' file='../fx_static_content.html'/>
 
 <%
+id_tag = page_contents.get('key')
+if id_tag:
+    id_tag = f'id="{id_tag}"'
+
 fx_title = fx_static._(page_contents.get('title'))
 fx_description = fx_static._(page_contents.get('description'))
 fx_image_url = page_contents.get('side_image')
@@ -15,7 +19,7 @@ if isinstance(is_reversed, str):
 fx_style = f'flex-direction: row-reverse' if is_reversed else ''
 %>
 
-<div class="row platformMainWrap" style="${fx_style}">
+<div ${id_tag} class="row platformMainWrap" style="${fx_style}">
     <div class="col-12 col-sm-6 d-flex flex-column justify-content-center">
         <h2 class="sectionWrapper__sectionHeading" style="text-align:start !important;">
             ${fx_title | fx_static.br}

--- a/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_page/_section_static_metrics_section_v1.html
+++ b/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_page/_section_static_metrics_section_v1.html
@@ -3,6 +3,10 @@
 <%namespace name='fx_static' file='../fx_static_content.html'/>
 
 <%
+id_tag = page_contents.get('key')
+if id_tag:
+    id_tag = f'id="{id_tag}"'
+
 fx_title = fx_static._(page_contents.get('title'))
 fx_description = fx_static._(page_contents.get('description'))
 fx_list_of_static_metrics = page_contents.get('list_of_static_metrics')
@@ -11,7 +15,7 @@ alignment = page_contents.get('alignment')
 alignment = alignment if alignment in ['start', 'end'] else 'center'
 %>
 
-<div class="platformMainWrap">
+<div ${id_tag} class="platformMainWrap">
     % if fx_title or fx_description:
     <div class="middleHeading">
         % if fx_title:

--- a/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_page/_section_two_columns_v1.html
+++ b/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_page/_section_two_columns_v1.html
@@ -3,6 +3,10 @@
 <%namespace name='fx_static' file='../fx_static_content.html'/>
 
 <%
+id_tag = page_contents.get('key')
+if id_tag:
+    id_tag = f'id="{id_tag}"'
+
 fx_title = fx_static._(page_contents.get('title'))
 fx_description = fx_static._(page_contents.get('description'))
 declared_columns_section = page_contents.get('columns_section', [])
@@ -12,7 +16,7 @@ for i in range(min(3, len(declared_columns_section))):
     columns_sections.append(declared_columns_section[i])
 %>
 
-<div class="platformMainWrap px-0">
+<div ${id_tag} class="platformMainWrap px-0">
     % if fx_title:
         <h2 class="sectionWrapper__sectionHeading">
         ${fx_title | fx_static.br}

--- a/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_page/page.html
+++ b/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_page/page.html
@@ -24,3 +24,16 @@ the_page = fx_static.get_fx_config_value(page_name)
     % endif
 </div>
 </div>
+
+
+<script>
+window.addEventListener('message', function (event) {
+    const { type, previewId } = event.data || {};
+    if (type === 'scroll-to-preview' && previewId) {
+        const el = document.getElementById(previewId);
+        if (el) {
+            el.scrollIntoView({ behavior: 'smooth' });
+        }
+    }
+});
+</script>


### PR DESCRIPTION
## Description:

feat: autoscroll on preview. Handling that through `postMessage` from the Theme Editor. The editor will post a message to the this theme to scroll the preview to a specific `div` component, or to `header` or `footer`. 

```js
postMessage(
        {
          type: 'scroll-to-preview',
          previewId,
        }
....)
```
`previewId` will be one of the following:
* `fx-header`: scroll to header
* `fx-footer` scroll to footer
* `<<section-key>>`: the `key` value of the page section (which is the ID of the main `div` of that section

### Related Issue:
