### PR TITLE
fix: course card title and alt property fixes

### DIFF
--- a/tutorindigo/templates/indigo/lms/templates/course.html
+++ b/tutorindigo/templates/indigo/lms/templates/course.html
@@ -25,7 +25,7 @@ else:
         <section class="course-info" aria-hidden="true">
             <h2 class="course-name">
                 <span class="course-code">${course.display_number_with_default}</span>
-                <span class="course-title">${course.display_number_with_default}</span>
+                <span class="course-title">${course.display_name_with_default}</span>
                 <span class="course-organization">${course.display_org_with_default}</span>
             </h2>
             <a href="${reverse('about_course', args=[str(course.id)])}" class="learn-more">${_("LEARN MORE")}</a>

--- a/tutorindigo/templates/indigo/lms/templates/course.html
+++ b/tutorindigo/templates/indigo/lms/templates/course.html
@@ -19,7 +19,7 @@ else:
         <header class="course-image">
             <div class="cover-image">
                 <!-- NEW IN INDIGO: Add fallback image in case of no course-image using onerror -->
-                <img src="${course.course_image_url}" onerror="this.src='/theming/asset/images/no_course_image.png';" alt="${course.display_name_with_default} ${course.display_number_with_default}" />
+                <img src="${course.course_image_url}" onerror="this.src='/theming/asset/images/no_course_image.png';" alt="${course.display_number_with_default} ${course.display_name_with_default}" />
             </div>
         </header>
         <section class="course-info" aria-hidden="true">
@@ -59,7 +59,7 @@ else:
     <div class="newCard">
         <div class="newCard__detailWrap">
             <div class="newCard__detail">
-                <img src="${course.course_image_url}" onerror="this.src='/theming/asset/images/no_course_image.png';" alt="${course.display_name_with_default} ${course.display_number_with_default}" class="newCard__courseImg"/>
+                <img src="${course.course_image_url}" onerror="this.src='/theming/asset/images/no_course_image.png';" alt="${course.display_number_with_default} - ${course.display_name_with_default}" class="newCard__courseImg"/>
                 <div class="newCard__courseName">${course.display_number_with_default}</div>
             </div>
             <div class="newCard__detail">


### PR DESCRIPTION
Course card title prints the course number instead:

![image](https://github.com/user-attachments/assets/3e604079-97f9-489a-b63e-d6017b4fb8f1)
