### PR TITLE
Enable dynamic addition of social media links in footer

### DIFF
--- a/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_footer_social_links.html
+++ b/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_footer_social_links.html
@@ -55,35 +55,35 @@ social_media_links = fx_static.get_fx_social_media_links(declared_social_media_l
         % elif social_link.get('provider') == 'snapchat':
             <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
                 <svg width="24" height="24" class="footerWrap__social-icon" aria-label="snapchat" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" >
-                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.5 2 4 6.3 4 10.3c0 2.7.8 4.5 1.5 5.5.5.7 1 1.4.6 2-.3.5-1.2.5-2 .7C4 19.7 5.8 21 8 21h8c2.2 0 4-1.3 3.9-2.3-.8-.2-1.7-.2-2-.7-.4-.6.1-1.3.6-2 .7-1 1.5-2.8 1.5-5.5 0-4-2.5-8.3-8-8.3z" fill="currentColor"></path>
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.5 2 4 6.3 4 10.3c0 2.7.8 4.5 1.5 5.5.5.7 1 1.4.6 2-.3.5-1.2.5-2 .7C4 19.7 5.8 21 8 21h8c2.2 0 4-1.3 3.9-2.3-.8-.2-1.7-.2-2-.7-.4-.6.1-1.3.6-2 .7-1 1.5-2.8 1.5-5.5 0-4-2.5-8.3-8-8.3z" fill="none"></path>
                 </svg>
             </a>
 
         % elif social_link.get('provider') == 'tiktok':
             <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
                 <svg width="24" height="24" class="footerWrap__social-icon" aria-label="tikTok" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2v13.5a2.5 2.5 0 1 1-2.5-2.5V10a5 5 0 1 0 5 5V7.7a6.3 6.3 0 0 0 4 1.3V6.5a4.9 4.9 0 0 1-4-1.5V2h-2.5z" fill="currentColor" ></path>
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2v13.5a2.5 2.5 0 1 1-2.5-2.5V10a5 5 0 1 0 5 5V7.7a6.3 6.3 0 0 0 4 1.3V6.5a4.9 4.9 0 0 1-4-1.5V2h-2.5z" fill="none" ></path>
                 </svg>
             </a>
         
         % elif social_link.get('provider') == 'pinterest':
             <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
                 <svg width="24" height="24" class="footerWrap__social-icon" aria-label="pinterest" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" >
-                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2a10 10 0 0 0-3.6 19.3c-.1-.8-.2-2 .1-2.8.3-.9 1.9-6.2 1.9-6.2s-.5-1-.5-2.5c0-2.3 1.3-4 3-4 1.4 0 2 1.1 2 2.5 0 1.5-.9 3.7-1.3 5.7-.4 1.5.8 2.8 2.3 2.8 2.7 0 4.8-2.8 4.8-6.9 0-3.6-2.6-6.2-6.2-6.2-4.2 0-6.7 3.2-6.7 6.5 0 1.3.5 2.6 1.1 3.3.1.1.1.2.1.3-.1.3-.3 1-.3 1.2-.1.2-.2.3-.5.2-1.4-.6-2.2-2.5-2.2-4.1 0-3.2 2.6-7.2 7.8-7.2 4.2 0 7.5 3 7.5 7.1 0 4.2-2.6 7.6-6.2 7.6-1.2 0-2.3-.6-2.7-1.4l-.7 2.7c-.3 1-1 2.3-1.5 3.1A10 10 0 1 0 12 2z" fill="currentColor" ></path>
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2a10 10 0 0 0-3.6 19.3c-.1-.8-.2-2 .1-2.8.3-.9 1.9-6.2 1.9-6.2s-.5-1-.5-2.5c0-2.3 1.3-4 3-4 1.4 0 2 1.1 2 2.5 0 1.5-.9 3.7-1.3 5.7-.4 1.5.8 2.8 2.3 2.8 2.7 0 4.8-2.8 4.8-6.9 0-3.6-2.6-6.2-6.2-6.2-4.2 0-6.7 3.2-6.7 6.5 0 1.3.5 2.6 1.1 3.3.1.1.1.2.1.3-.1.3-.3 1-.3 1.2-.1.2-.2.3-.5.2-1.4-.6-2.2-2.5-2.2-4.1 0-3.2 2.6-7.2 7.8-7.2 4.2 0 7.5 3 7.5 7.1 0 4.2-2.6 7.6-6.2 7.6-1.2 0-2.3-.6-2.7-1.4l-.7 2.7c-.3 1-1 2.3-1.5 3.1A10 10 0 1 0 12 2z" fill="none" ></path>
                 </svg>
             </a>
 
         % elif social_link.get('provider') == 'telegram':
             <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
                 <svg width="24" height="24" class="footerWrap__social-icon" aria-label="telegram" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" > 
-                    <path fill-rule="evenodd" clip-rule="evenodd" d="M9.4 16.9 9 20.6c.5 0 .8-.2 1.1-.5l2.7-2.6 5.6 4.1c1 .6 1.7.3 2-.9l3.6-15.9c.3-1.3-.4-1.8-1.4-1.5L2 10.2c-1.3.4-1.2 1.3-.2 1.6l5.6 1.7 13-8-9.9 9.3z" fill="currentColor" ></path>
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M9.4 16.9 9 20.6c.5 0 .8-.2 1.1-.5l2.7-2.6 5.6 4.1c1 .6 1.7.3 2-.9l3.6-15.9c.3-1.3-.4-1.8-1.4-1.5L2 10.2c-1.3.4-1.2 1.3-.2 1.6l5.6 1.7 13-8-9.9 9.3z" fill="none" ></path>
                 </svg>
             </a>
 
         % elif social_link.get('provider') == 'whatsapp':
             <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
                 <svg width="24" height="24" class="footerWrap__social-icon" aria-label="whatsApp" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" >
-                    <circle cx="12" cy="12" r="10" fill="currentColor" ></circle>
+                    <circle cx="12" cy="12" r="10" fill="none" ></circle>
                     <path fill-rule="evenodd" clip-rule="evenodd" d="M16.2 13.7c-.3-.2-1.4-.7-1.7-.8s-.4-.1-.6.2c-.2.3-.5.6-.7.8-.1.1-.2.2-.4.1-.7-.4-1.4-.8-2-1.4s-1-1.3-1.4-2c0-.2 0-.3.1-.4.2-.2.4-.5.6-.7.2-.2.2-.4.1-.6-.1-.3-.6-1.4-.8-1.7s-.4-.3-.6-.3h-.5c-.3 0-.7.1-1 .4-.5.5-.9 1.3-.9 2.1 0 .2 0 .4.1.6.3 1 .9 2 1.6 2.9.8.9 1.7 1.6 2.7 2.1.6.3 1.1.5 1.5.6.5.1.8.1 1.1.1.8 0 1.6-.4 2.1-.9.3-.3.4-.7.4-1v-.5c0-.2-.1-.5-.3-.6z" fill="#fff" ></path>
                 </svg>
             </a>
@@ -91,33 +91,33 @@ social_media_links = fx_static.get_fx_social_media_links(declared_social_media_l
         % elif social_link.get('provider') == 'behance':
             <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
                 <svg width="24" height="24" class="footerWrap__social-icon" aria-label="behance" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" >
-                    <path fill-rule="evenodd" clip-rule="evenodd" d="M2 4v16h20V4H2zm5.6 6.4H4.5V7.2h3.2c.8 0 1.4.6 1.4 1.6s-.6 1.6-1.5 1.6zM4.5 13.9h3.4c.9 0 1.5.7 1.5 1.5s-.7 1.6-1.6 1.6H4.5v-3.1zM12.6 8.4h6.6v1.2h-6.6V8.4zm2.8 2.3c-2 0-2.9 1-2.9 3s1.3 3.3 3.2 3.3 2.8-.8 3.1-2.2h-1.7c-.2.5-.7.7-1.3.7-.9 0-1.4-.6-1.5-1.5h4.7a3.1 3.1 0 0 0-3.3-3.3z" fill="currentColor" ></path>
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M2 4v16h20V4H2zm5.6 6.4H4.5V7.2h3.2c.8 0 1.4.6 1.4 1.6s-.6 1.6-1.5 1.6zM4.5 13.9h3.4c.9 0 1.5.7 1.5 1.5s-.7 1.6-1.6 1.6H4.5v-3.1zM12.6 8.4h6.6v1.2h-6.6V8.4zm2.8 2.3c-2 0-2.9 1-2.9 3s1.3 3.3 3.2 3.3 2.8-.8 3.1-2.2h-1.7c-.2.5-.7.7-1.3.7-.9 0-1.4-.6-1.5-1.5h4.7a3.1 3.1 0 0 0-3.3-3.3z" fill="none" ></path>
                 </svg>
             </a>
 
         % elif social_link.get('provider') == 'dribbble':
             <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
                 <svg width="24" height="24" class="footerWrap__social-icon" aria-label="dribbble" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" > 
-                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zm6.4 4.4c1.1 1.4 1.7 3.2 1.6 5.1-.7-.1-3.5-.5-6.4.2-.2-.5-.5-1-.7-1.5 3.2-1.3 4.7-3.2 5.5-3.8zM12 4c1.7 0 3.3.6 4.6 1.6-.7.9-2 2.1-4.5 3.1A32 32 0 0 0 9 5.1c.9-.7 2.1-1.1 3-1.1zM6.2 6.7c.6-.6 1.4-1.1 2.3-1.5a33 33 0 0 1 3.1 3.8c-2.7 1-5.4 1.2-6.6 1.2-.1-1.3.3-2.3 1.2-3.5zM4 12v-.4c1.3 0 4.6 0 7.6-1.2.2.3.4.6.6 1-3.7 1.4-5.6 4.2-6.2 5.1A8 8 0 0 1 4 12zm8 8c-1.2 0-2.4-.3-3.4-.8.5-1 2.2-3.6 6.4-5a15 15 0 0 1 1.6 5.6 8 8 0 0 1-4.6.2zm6.1-2.1c-.1-1.7-.6-3.2-1.1-4.5 2.2-.3 4.2.3 5 .5a8 8 0 0 1-3.9 4z" fill="currentColor" ></path>
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zm6.4 4.4c1.1 1.4 1.7 3.2 1.6 5.1-.7-.1-3.5-.5-6.4.2-.2-.5-.5-1-.7-1.5 3.2-1.3 4.7-3.2 5.5-3.8zM12 4c1.7 0 3.3.6 4.6 1.6-.7.9-2 2.1-4.5 3.1A32 32 0 0 0 9 5.1c.9-.7 2.1-1.1 3-1.1zM6.2 6.7c.6-.6 1.4-1.1 2.3-1.5a33 33 0 0 1 3.1 3.8c-2.7 1-5.4 1.2-6.6 1.2-.1-1.3.3-2.3 1.2-3.5zM4 12v-.4c1.3 0 4.6 0 7.6-1.2.2.3.4.6.6 1-3.7 1.4-5.6 4.2-6.2 5.1A8 8 0 0 1 4 12zm8 8c-1.2 0-2.4-.3-3.4-.8.5-1 2.2-3.6 6.4-5a15 15 0 0 1 1.6 5.6 8 8 0 0 1-4.6.2zm6.1-2.1c-.1-1.7-.6-3.2-1.1-4.5 2.2-.3 4.2.3 5 .5a8 8 0 0 1-3.9 4z" fill="none" ></path>
                 </svg>
             </a>
 
         % elif social_link.get('provider') == 'reddit':
             <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
-                <svg width="24" height="24" class="footerWrap__social-icon" aria-label="reddit" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" > <path fill-rule="evenodd" clip-rule="evenodd" d="M24 12c0 6.6-5.4 12-12 12S0 18.6 0 12 5.4 0 12 0s12 5.4 12 12zM6 10a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zm12 0a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zm-6 6c-2.1 0-3.9-.9-4-2h8c-.1 1.1-1.9 2-4 2zm3.2-8.6 1-4.8 4.3 1c.4.1.8-.2.9-.6s-.2-.8-.6-.9l-5.2-1.2a.8.8 0 0 0-1 .6l-1.1 5.1a6.8 6.8 0 0 0-7 3.2c-.2.3 0 .8.3 1a.8.8 0 0 0 1-.3c.9-1.6 2.8-2.6 4.7-2.6s3.8 1 4.7 2.6a.8.8 0 0 0 1.1.3c.3-.2.5-.7.2-1.1a6.8 6.8 0 0 0-4.3-3.3z" fill="currentColor" ></path>
+                <svg width="24" height="24" class="footerWrap__social-icon" aria-label="reddit" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" > <path fill-rule="evenodd" clip-rule="evenodd" d="M24 12c0 6.6-5.4 12-12 12S0 18.6 0 12 5.4 0 12 0s12 5.4 12 12zM6 10a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zm12 0a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zm-6 6c-2.1 0-3.9-.9-4-2h8c-.1 1.1-1.9 2-4 2zm3.2-8.6 1-4.8 4.3 1c.4.1.8-.2.9-.6s-.2-.8-.6-.9l-5.2-1.2a.8.8 0 0 0-1 .6l-1.1 5.1a6.8 6.8 0 0 0-7 3.2c-.2.3 0 .8.3 1a.8.8 0 0 0 1-.3c.9-1.6 2.8-2.6 4.7-2.6s3.8 1 4.7 2.6a.8.8 0 0 0 1.1.3c.3-.2.5-.7.2-1.1a6.8 6.8 0 0 0-4.3-3.3z" fill="none" ></path>
                 </svg>
             </a>
 
         % elif social_link.get('provider') == 'github':
             <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
-                <svg width="24" height="24" class="footerWrap__social-icon" aria-label="gitHub" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" > <path fill-rule="evenodd" clip-rule="evenodd" d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2c-3.3.7-4-1.4-4-1.4a3.2 3.2 0 0 0-1.3-1.8c-1-.6.1-.6.1-.6a2.5 2.5 0 0 1 1.8 1.2c1 .1 1.5-.5 1.8-.9a2.7 2.7 0 0 1 .8-1.6c-2.7-.3-5.5-1.3-5.5-6a4.6 4.6 0 0 1 1.2-3.1c-.1-.3-.5-1.4.1-2.8 0 0 1-.3 3.2 1.2a11 11 0 0 1 5.8 0c2.2-1.5 3.2-1.2 3.2-1.2.6 1.4.2 2.5.1 2.8a4.6 4.6 0 0 1 1.2 3.1c0 4.8-2.8 5.7-5.5 6a3 3 0 0 1 .9 2.3v3.4c0 .4.3.8.9.6A12 12 0 0 0 12 .3z" fill="currentColor" ></path>
+                <svg width="24" height="24" class="footerWrap__social-icon" aria-label="gitHub" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" > <path fill-rule="evenodd" clip-rule="evenodd" d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2c-3.3.7-4-1.4-4-1.4a3.2 3.2 0 0 0-1.3-1.8c-1-.6.1-.6.1-.6a2.5 2.5 0 0 1 1.8 1.2c1 .1 1.5-.5 1.8-.9a2.7 2.7 0 0 1 .8-1.6c-2.7-.3-5.5-1.3-5.5-6a4.6 4.6 0 0 1 1.2-3.1c-.1-.3-.5-1.4.1-2.8 0 0 1-.3 3.2 1.2a11 11 0 0 1 5.8 0c2.2-1.5 3.2-1.2 3.2-1.2.6 1.4.2 2.5.1 2.8a4.6 4.6 0 0 1 1.2 3.1c0 4.8-2.8 5.7-5.5 6a3 3 0 0 1 .9 2.3v3.4c0 .4.3.8.9.6A12 12 0 0 0 12 .3z" fill="none" ></path>
                 </svg>
             </a>
 
         % elif social_link.get('provider') == 'other':
             <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
                 <svg width="24" height="24" class="footerWrap__social-icon" aria-label="other" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <circle cx="12" cy="12" r="10" fill="currentColor" ></circle>
+                    <circle cx="12" cy="12" r="10" fill="none" ></circle>
                     <text x="50%" y="55%" dominantBaseline="middle" textAnchor="middle" fontSize="10" fill="#ffffff" > ? </text>
                 </svg>
             </a>

--- a/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_footer_social_links.html
+++ b/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_footer_social_links.html
@@ -51,6 +51,76 @@ social_media_links = fx_static.get_fx_social_media_links(declared_social_media_l
                     <path d="M11.9674 8.82647L17.8687 2H15.2344L10.7299 7.21374L6.7339 2H1L7.6906 10.7273L1.4032 18H4.0375L8.9281 12.3444L13.2661 18H19L11.9674 8.82647ZM9.9271 11.1868L8.6896 9.57141L3.88 3.30167H5.86L9.7408 8.35546L10.9783 9.97084L16.1362 16.6983H14.1562L9.9271 11.1868Z"></path>
                 </svg>
             </a>
+            
+        % elif social_link.get('provider') == 'snapchat':
+            <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
+                <svg width="24" height="24" class="footerWrap__social-icon" aria-label="snapchat" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" >
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.5 2 4 6.3 4 10.3c0 2.7.8 4.5 1.5 5.5.5.7 1 1.4.6 2-.3.5-1.2.5-2 .7C4 19.7 5.8 21 8 21h8c2.2 0 4-1.3 3.9-2.3-.8-.2-1.7-.2-2-.7-.4-.6.1-1.3.6-2 .7-1 1.5-2.8 1.5-5.5 0-4-2.5-8.3-8-8.3z" fill="currentColor"></path>
+                </svg>
+            </a>
+
+        % elif social_link.get('provider') == 'tiktok':
+            <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
+                <svg width="24" height="24" class="footerWrap__social-icon" aria-label="tikTok" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2v13.5a2.5 2.5 0 1 1-2.5-2.5V10a5 5 0 1 0 5 5V7.7a6.3 6.3 0 0 0 4 1.3V6.5a4.9 4.9 0 0 1-4-1.5V2h-2.5z" fill="currentColor" ></path>
+                </svg>
+            </a>
+        
+        % elif social_link.get('provider') == 'pinterest':
+            <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
+                <svg width="24" height="24" class="footerWrap__social-icon" aria-label="pinterest" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" >
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2a10 10 0 0 0-3.6 19.3c-.1-.8-.2-2 .1-2.8.3-.9 1.9-6.2 1.9-6.2s-.5-1-.5-2.5c0-2.3 1.3-4 3-4 1.4 0 2 1.1 2 2.5 0 1.5-.9 3.7-1.3 5.7-.4 1.5.8 2.8 2.3 2.8 2.7 0 4.8-2.8 4.8-6.9 0-3.6-2.6-6.2-6.2-6.2-4.2 0-6.7 3.2-6.7 6.5 0 1.3.5 2.6 1.1 3.3.1.1.1.2.1.3-.1.3-.3 1-.3 1.2-.1.2-.2.3-.5.2-1.4-.6-2.2-2.5-2.2-4.1 0-3.2 2.6-7.2 7.8-7.2 4.2 0 7.5 3 7.5 7.1 0 4.2-2.6 7.6-6.2 7.6-1.2 0-2.3-.6-2.7-1.4l-.7 2.7c-.3 1-1 2.3-1.5 3.1A10 10 0 1 0 12 2z" fill="currentColor" ></path>
+                </svg>
+            </a>
+
+        % elif social_link.get('provider') == 'telegram':
+            <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
+                <svg width="24" height="24" class="footerWrap__social-icon" aria-label="telegram" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" > 
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M9.4 16.9 9 20.6c.5 0 .8-.2 1.1-.5l2.7-2.6 5.6 4.1c1 .6 1.7.3 2-.9l3.6-15.9c.3-1.3-.4-1.8-1.4-1.5L2 10.2c-1.3.4-1.2 1.3-.2 1.6l5.6 1.7 13-8-9.9 9.3z" fill="currentColor" ></path>
+                </svg>
+            </a>
+
+        % elif social_link.get('provider') == 'whatsapp':
+            <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
+                <svg width="24" height="24" class="footerWrap__social-icon" aria-label="whatsApp" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" >
+                    <circle cx="12" cy="12" r="10" fill="currentColor" ></circle>
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M16.2 13.7c-.3-.2-1.4-.7-1.7-.8s-.4-.1-.6.2c-.2.3-.5.6-.7.8-.1.1-.2.2-.4.1-.7-.4-1.4-.8-2-1.4s-1-1.3-1.4-2c0-.2 0-.3.1-.4.2-.2.4-.5.6-.7.2-.2.2-.4.1-.6-.1-.3-.6-1.4-.8-1.7s-.4-.3-.6-.3h-.5c-.3 0-.7.1-1 .4-.5.5-.9 1.3-.9 2.1 0 .2 0 .4.1.6.3 1 .9 2 1.6 2.9.8.9 1.7 1.6 2.7 2.1.6.3 1.1.5 1.5.6.5.1.8.1 1.1.1.8 0 1.6-.4 2.1-.9.3-.3.4-.7.4-1v-.5c0-.2-.1-.5-.3-.6z" fill="#fff" ></path>
+                </svg>
+            </a>
+
+        % elif social_link.get('provider') == 'behance':
+            <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
+                <svg width="24" height="24" class="footerWrap__social-icon" aria-label="behance" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" >
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M2 4v16h20V4H2zm5.6 6.4H4.5V7.2h3.2c.8 0 1.4.6 1.4 1.6s-.6 1.6-1.5 1.6zM4.5 13.9h3.4c.9 0 1.5.7 1.5 1.5s-.7 1.6-1.6 1.6H4.5v-3.1zM12.6 8.4h6.6v1.2h-6.6V8.4zm2.8 2.3c-2 0-2.9 1-2.9 3s1.3 3.3 3.2 3.3 2.8-.8 3.1-2.2h-1.7c-.2.5-.7.7-1.3.7-.9 0-1.4-.6-1.5-1.5h4.7a3.1 3.1 0 0 0-3.3-3.3z" fill="currentColor" ></path>
+                </svg>
+            </a>
+
+        % elif social_link.get('provider') == 'dribbble':
+            <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
+                <svg width="24" height="24" class="footerWrap__social-icon" aria-label="dribbble" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" > 
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zm6.4 4.4c1.1 1.4 1.7 3.2 1.6 5.1-.7-.1-3.5-.5-6.4.2-.2-.5-.5-1-.7-1.5 3.2-1.3 4.7-3.2 5.5-3.8zM12 4c1.7 0 3.3.6 4.6 1.6-.7.9-2 2.1-4.5 3.1A32 32 0 0 0 9 5.1c.9-.7 2.1-1.1 3-1.1zM6.2 6.7c.6-.6 1.4-1.1 2.3-1.5a33 33 0 0 1 3.1 3.8c-2.7 1-5.4 1.2-6.6 1.2-.1-1.3.3-2.3 1.2-3.5zM4 12v-.4c1.3 0 4.6 0 7.6-1.2.2.3.4.6.6 1-3.7 1.4-5.6 4.2-6.2 5.1A8 8 0 0 1 4 12zm8 8c-1.2 0-2.4-.3-3.4-.8.5-1 2.2-3.6 6.4-5a15 15 0 0 1 1.6 5.6 8 8 0 0 1-4.6.2zm6.1-2.1c-.1-1.7-.6-3.2-1.1-4.5 2.2-.3 4.2.3 5 .5a8 8 0 0 1-3.9 4z" fill="currentColor" ></path>
+                </svg>
+            </a>
+
+        % elif social_link.get('provider') == 'reddit':
+            <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
+                <svg width="24" height="24" class="footerWrap__social-icon" aria-label="reddit" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" > <path fill-rule="evenodd" clip-rule="evenodd" d="M24 12c0 6.6-5.4 12-12 12S0 18.6 0 12 5.4 0 12 0s12 5.4 12 12zM6 10a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zm12 0a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3zm-6 6c-2.1 0-3.9-.9-4-2h8c-.1 1.1-1.9 2-4 2zm3.2-8.6 1-4.8 4.3 1c.4.1.8-.2.9-.6s-.2-.8-.6-.9l-5.2-1.2a.8.8 0 0 0-1 .6l-1.1 5.1a6.8 6.8 0 0 0-7 3.2c-.2.3 0 .8.3 1a.8.8 0 0 0 1-.3c.9-1.6 2.8-2.6 4.7-2.6s3.8 1 4.7 2.6a.8.8 0 0 0 1.1.3c.3-.2.5-.7.2-1.1a6.8 6.8 0 0 0-4.3-3.3z" fill="currentColor" ></path>
+                </svg>
+            </a>
+
+        % elif social_link.get('provider') == 'github':
+            <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
+                <svg width="24" height="24" class="footerWrap__social-icon" aria-label="gitHub" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" > <path fill-rule="evenodd" clip-rule="evenodd" d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2c-3.3.7-4-1.4-4-1.4a3.2 3.2 0 0 0-1.3-1.8c-1-.6.1-.6.1-.6a2.5 2.5 0 0 1 1.8 1.2c1 .1 1.5-.5 1.8-.9a2.7 2.7 0 0 1 .8-1.6c-2.7-.3-5.5-1.3-5.5-6a4.6 4.6 0 0 1 1.2-3.1c-.1-.3-.5-1.4.1-2.8 0 0 1-.3 3.2 1.2a11 11 0 0 1 5.8 0c2.2-1.5 3.2-1.2 3.2-1.2.6 1.4.2 2.5.1 2.8a4.6 4.6 0 0 1 1.2 3.1c0 4.8-2.8 5.7-5.5 6a3 3 0 0 1 .9 2.3v3.4c0 .4.3.8.9.6A12 12 0 0 0 12 .3z" fill="currentColor" ></path>
+                </svg>
+            </a>
+
+        % elif social_link.get('provider') == 'other':
+            <a class="btn p-0" href="${social_link.get('value')}" target="_blank" rel="noopener">
+                <svg width="24" height="24" class="footerWrap__social-icon" aria-label="other" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <circle cx="12" cy="12" r="10" fill="currentColor" ></circle>
+                    <text x="50%" y="55%" dominantBaseline="middle" textAnchor="middle" fontSize="10" fill="#ffffff" > ? </text>
+                </svg>
+            </a>
         % endif
     % endfor
     </div>


### PR DESCRIPTION
**Description**  
This PR enables dynamic management of social media platforms in the footer section.

---

### ✅ What's New

- Users can now add new social media entries via a configurable list
- Supported platforms:
  - Facebook
  - Instagram
  - Twitter (X)
  - LinkedIn
  - YouTube
  - Snapchat
  - TikTok
  - Pinterest
  - Telegram
  - WhatsApp
  - Behance
  - Dribbble
  - Reddit
  - GitHub
  - Other (custom)

---

### 🧩 Technical Details

- Used a dropdown/select field populated with the supported providers
- Stored as an array of `{ label, value }` for clean UI rendering
- The selected provider maps directly to its corresponding SVG icon in the footer

---

**Related Issues**  
* https://github.com/zeit-labs/dashboard/issues/456
