### PR TITLE
fix: revert link to use get_home_url instead of get_base_url

### DIFF
--- a/tutorindigo/templates/indigo/lms/templates/header/navbar-logo-header.html
+++ b/tutorindigo/templates/indigo/lms/templates/header/navbar-logo-header.html
@@ -28,7 +28,7 @@ enterprise_customer_link = get_enterprise_learner_portal(request)
         % endif
     </a>
   % else:
-    <a href="${branding_api.get_base_url()}">
+    <a href="${branding_api.get_home_url()}">
       <%block name="navigation_logo">
         <img  class="logo" src="${fx_static.fx_get_logo_image_url()}" alt="${_("{platform_name} Home Page").format(platform_name=static.get_platform_name())}"/>
       </%block>


### PR DESCRIPTION
## Description:

fix: revert link to use get_home_url instead of get_base_url

### Related Issue:
