### PR TITLE
fix: Mako mix with Django Template

### DIFF
--- a/tutorindigo/templates/indigo/lms/templates/head-extra.html
+++ b/tutorindigo/templates/indigo/lms/templates/head-extra.html
@@ -1,3 +1,4 @@
+## mako
 <%namespace name='static' file='static_content.html'/>
 <% style_overrides_file = static.get_value('css_overrides_file') %>
 


### PR DESCRIPTION
## Description:

fix: Mako mix with Django Template

Adding the comment will enable Mako render by edx engine

### Related Issue:

* https://zeitlabs.atlassian.net/browse/FX-99
