### PR TITLE
fix: prevent RTL-to-LTR flip by restricting user profile initializati…

### DIFF
--- a/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_head_extra.html
+++ b/tutorindigo/templates/indigo/lms/templates/fx_templates/fx_head_extra.html
@@ -115,6 +115,8 @@ html {
     % endfor
 % endif
 
-<div class="user-profile-form-container" >
-  <%include file="../user_profile/index.html" />
-</div>
+% if user.is_authenticated:
+    <div class="user-profile-form-container" >
+      <%include file="../user_profile/index.html" />
+    </div>
+% endif


### PR DESCRIPTION
## Description
This PR fixes a layout bug where the page direction would incorrectly flip from RTL to LTR during the initial load in Incognito mode (or for unauthenticated users).

The issue was caused by the `@edx/frontend-platform` initialization script within the User Profile component. Since anonymous users lack the `openedx-language-preference` cookie, the JavaScript `initialize` function was defaulting to LTR and overriding the global `dir` attribute on the `<html>` tag.

By wrapping the `user_profile` template inclusion in an authentication check, we ensure this script only executes when a valid user session (and its corresponding language preferences) exists.

## Changes
- Modified `fx_head_extra` to wrap the user profile form container in a conditional check.
- Prevented the execution of the User Profile React initialization for unauthenticated users.

## Screenshots

### Before
| Environment | Direction | Observation |
| :--- | :--- | :--- |
| Incognito / Guest | LTR (Incorrect) | The page starts in RTL and flips to LTR after JS execution. |
<img width="1869" height="630" alt="image" src="https://github.com/user-attachments/assets/7dde1c5f-3ead-437b-ab08-f09e9e85776d" />

### After
| Environment | Direction | Observation |
| :--- | :--- | :--- |
| Incognito / Guest | RTL (Correct) | The page maintains the server-side RTL direction. |
| Authenticated | RTL (Correct) | The profile modal initializes correctly with user preferences. |

<img width="1889" height="968" alt="image" src="https://github.com/user-attachments/assets/b2a2431b-fde4-44a4-a6d5-5c8158793ad4" />

<img width="1782" height="667" alt="image" src="https://github.com/user-attachments/assets/4601b16a-c410-4824-aea4-3656928fc95c" />
