### PR TITLE
fix: correct horizontal alignment for course profile header and media…

### DIFF
--- a/tutorindigo/templates/indigo/lms/static/sass/courseware/_about.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/courseware/_about.scss
@@ -55,6 +55,7 @@
       display: block;
       max-width: 400px;
       width: 100%;
+      align-self: flex-end;
       @include media-breakpoint-up(md) {
         float: right;
         width: 32%;
@@ -639,6 +640,7 @@ body.indigo-dark-theme {
           padding: 10px 0 40px !important;
           .profile-top {
             flex-direction: column;
+            align-items: flex-start;
             .info-profile {
               padding-bottom: 20px;
             }


### PR DESCRIPTION
## Description
This PR addresses a layout regression in the Course About page when viewed on mobile/small screens (under 992px) in RTL mode. 

When the layout switched to `flex-direction: column`, the header text was losing its right-alignment, and the media/video element was defaulting to the right side (start of RTL), which was visually inconsistent. 

## Changes
- Updated `.profile-top` to use `align-items: flex-start` in responsive mode to keep text correctly aligned to the right in RTL.
- Applied `align-self: flex-end` to the `.media` (video) container to push it to the left side of the column, maintaining visual balance in RTL without breaking LTR logic.
- Added necessary padding adjustments for the `.intro-inner-wrapper` in mobile views.

## Screenshots

### Before
| Mobile View (RTL) | Observation |
| :--- | :--- |
| | The Title and Video were misaligned when stacked vertically. |
<img width="872" height="965" alt="image" src="https://github.com/user-attachments/assets/b874dc6e-b44f-41dd-924e-62da7ef9faf0" />

<img width="897" height="844" alt="image" src="https://github.com/user-attachments/assets/9a0a545c-be61-4bba-aa9d-98ed6d843d0c" />



### After
| Mobile View (RTL) | Observation |
| :--- | :--- |
| | Title stays on the right, and the video aligns to the left as expected in a column layout. |

<img width="640" height="1006" alt="image" src="https://github.com/user-attachments/assets/8063d744-c628-41bb-8ee2-c9afe490529b" />
<img width="904" height="967" alt="image" src="https://github.com/user-attachments/assets/e214ed55-7b9d-4e57-ae92-3ee3a22a6fef" />

